### PR TITLE
 Fix typo in lec-combinatorics

### DIFF
--- a/typst/lec-combinatorics.typ
+++ b/typst/lec-combinatorics.typ
@@ -984,7 +984,7 @@ Let's state the principle of inclusion-exclusion using a rigid pattern:
   A function from $[n]$ to $[n]$ is a _surjection_ iff it is a _bijection_.
   Since there are $n!$ bijections on $[n]$ (namely, all permutations), we have the following identity:
   $
-    n! = sum_(i = 0)^n (-1)^i binom(n, i) (n - i)^i
+    n! = sum_(i = 0)^n (-1)^i binom(n, i) (n - i)^n
   $
 ]
 


### PR DESCRIPTION
Typo in the corollary 15.1, changed power of i to power of n