### PR TITLE
Fixed typo

### DIFF
--- a/cheat6.tex
+++ b/cheat6.tex
@@ -170,7 +170,7 @@
         \item $Q = \Set{q_1, \dots, q_n}$ is a finite set of states;
         \item $q_0 \in Q$ is an initial state;
         \item $F \subseteq Q$ is set of final (terminal, accepting) states;
-        \item $\delta \colon Q \times \Sigma \to Q$ is transition function.
+        \item $\delta \colon Q \times \Sigma \to Q$ is a transition function.
     \end{terms}
 
     \item Language \textbf{accepted} by an automaton $\mathcal{A}$ is the set $L(\mathcal{A}) = \Set{w \given \delta(q_0, w) \in F}$.


### PR DESCRIPTION
There must "Q is a transition function" and not just "Q is transition function"