### PR TITLE
Fix Venn diagram filling in сomplement

### DIFF
--- a/typst/lec-set-theory.typ
+++ b/typst/lec-set-theory.typ
@@ -896,6 +896,7 @@ The elements of the power set of ${a, b, c}$ ordered with respect to inclusion (
       not-ab-fill: purple.transparentize(80%),
       padding: .2,
       not-ab-stroke: 1pt + purple.darken(20%),
+      b-fill: purple.transparentize(80%),
     )
   ],
   // [Power set], [$2^A$ or $power(A)$], ${ S | S subset.eq A }$, [],


### PR DESCRIPTION
Fixed an error with filling circle B in the Venn diagram illustrating the сomplement operation.

### Comparison:
Before:
<img width="831" height="111" alt="image" src="https://github.com/user-attachments/assets/bf8b22e6-c3b1-4d23-bdb4-007dd7a04b28" />

After:
<img width="831" height="134" alt="image" src="https://github.com/user-attachments/assets/6158e472-48f4-42af-b41b-c372bd757fd2" />
