### PR TITLE
Fix Venn diagram for Complement operation

### DIFF
--- a/typst/lec-set-theory.typ
+++ b/typst/lec-set-theory.typ
@@ -892,11 +892,16 @@ The elements of the power set of ${a, b, c}$ ordered with respect to inclusion (
   [$overline(A)$ or $A^c$],
   ${ x | x notin A }$,
   [
-    #draw-venn2(
-      not-ab-fill: purple.transparentize(80%),
-      padding: .2,
-      not-ab-stroke: 1pt + purple.darken(20%),
-    )
+    #cetz.canvas({
+      import cetz.draw: *
+
+      rect((-0.9, -0.6), (0.9, 0.6),
+        fill: purple.transparentize(80%),
+        stroke: purple.darken(20%)
+      )
+      circle((0, 0), radius: .5, fill: white)
+      content((0, 0), [A])
+    })
   ],
   // [Power set], [$2^A$ or $power(A)$], ${ S | S subset.eq A }$, [],
 )


### PR DESCRIPTION
This PR fixes a Venn diagram for Complement operation.

Since there is no one-set diagram in [`cetz-venn`](https://typst.app/universe/package/cetz-venn/), the illustration is drawn using plain `cetz`.

## Comparison

Before:

<img width="3001" height="1683" alt="image" src="https://github.com/user-attachments/assets/adf43dc1-dfb1-4cb0-b746-1b0bbc9f4943" />


After:

<img width="3003" height="1685" alt="image" src="https://github.com/user-attachments/assets/7aa961b2-6957-4224-b9ae-9896acbec5c7" />
