### PR TITLE
Maximal chain typo fix in lec-relations

### DIFF
--- a/typst/lec-relations.typ
+++ b/typst/lec-relations.typ
@@ -1794,7 +1794,7 @@
   ]
 
   *Chains:* (totally ordered subsets)
-  - Maximal chain: #Blue[${1, 2, 4, 12}$] --- longest path
+  - Maximal chain: #Blue[${1, 2, 4, 20}$] --- longest path
   - Not maximal: ${5, 10}$
   - Can _skip_ elements: ${1, 5, 20}$
 


### PR DESCRIPTION
This PR fixes a typo in maximal chain.